### PR TITLE
Add counter with start and stop functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,24 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
 import "./App.css";
 
 function App() {
   const [count, setCount] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+
+  useEffect(() => {
+    if (isRunning) {
+      const interval = setInterval(() => {
+        setCount((currentCount) => currentCount + 1);
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [isRunning]);
+
+  const changeState = () => {
+    setIsRunning((currentState) => !currentState);
+  };
 
   return (
     <>
@@ -18,9 +32,8 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+        <button onClick={changeState}>{isRunning ? "Stop" : "Start"}</button>
+        <p>Counter: {count}</p>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>


### PR DESCRIPTION
Implemented a counter that increments by 1 every second when running. The counter's state can be toggled using a button to start and stop the counting process, managed with useState and useEffect hooks.